### PR TITLE
bug修复：当左侧存在禁用结点，从右侧移动到左侧时会把左侧未选中但禁用的结点全部激活；feature新增：新增右侧列表排序属性：listSortFifo

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 | filter-method | 自定义搜索方法 | function | — | — |
 | titles | 自定义标题 | array | — | ['源数据', '目标列表'] |
 | button-texts | 自定义按钮文案 | array | — | [ ] |
+| listSortFifo | 右侧列表排序方式：默认值：true，右侧列表中结点根据左侧树选中结点先后顺序排序；可选值：false，右侧列表中结点根据左侧树结构排序 | boolean | — | true |
 
 ### Slot
 

--- a/src/components/tree-transfer.vue
+++ b/src/components/tree-transfer.vue
@@ -221,6 +221,11 @@ export default {
       type: Array,
       default: () => [],
     },
+    // 右侧列表根据选择节点先后排序
+    listSortFifo: {
+      type: Boolean,
+      default: true,
+    },
   },
   computed: {
     // 左侧数据
@@ -404,7 +409,18 @@ export default {
           return item;
         }
       });
-      this.rightList = [...this.rightList, ...arrayDeWeighting];
+      /**
+       * feature新增：新增右侧列表排序属性：listSortFifo
+       * feature新增后功能：
+       * Boolean类型的listSortFifo属性
+       * 默认值：true，右侧列表中结点根据左侧树选中结点先后顺序排序
+       * 可选值：false，右侧列表中结点根据左侧树结构排序
+       */
+      if (this.listSortFifo) {
+        this.rightList = [...this.rightList, ...arrayDeWeighting];
+      } else {
+        this.rightList = [...arrayCheckedNodes];
+      }
       if (this.isRadio) {
         this.setDisable(this.treeFromData);
       } else {

--- a/src/components/tree-transfer.vue
+++ b/src/components/tree-transfer.vue
@@ -509,7 +509,17 @@ export default {
         if (choose) {
           this.$set(item, "disabled", true);
         } else {
-          this.$set(item, "disabled", false);
+          /**
+           * bug修复：当左侧存在禁用结点，从右侧移动到左侧时会把左侧未选中但禁用的结点全部激活
+           * bug修复后功能：
+           * 从左侧树移动到右侧列表时：
+           * 原来树结点是 disabled 状态的，保持不变
+           * 从右侧列表移动到左侧树时：
+           * 原来树中选中并禁用的结点，右侧移动回左侧后，取消选中和 disabled 状态
+           */
+          if (!item.disabled || this.$refs["from-tree"].getCheckedNodes().includes(item)) {
+            this.$set(item, "disabled", false);
+          }
         }
         if (this.isRadio && !this.fatherChoose && item.children.length > 0) {
           this.$set(item, "disabled", true);


### PR DESCRIPTION
一、bug修复：当左侧存在禁用结点，从右侧移动到左侧时会把左侧未选中但禁用的结点全部激活

bug修复后功能：
从左侧树移动到右侧列表时：
原来树结点是 disabled 状态的，保持不变
从右侧列表移动到左侧树时：
原来树中选中并禁用的结点，右侧移动回左侧后，取消选中和 disabled 状态

二、feature新增：新增右侧列表排序属性：listSortFifo

feature新增后功能：
Boolean类型的listSortFifo属性
默认值：true，右侧列表中结点根据左侧树选中结点先后顺序排序
可选值：false，右侧列表中结点根据左侧树结构排序
